### PR TITLE
support generic injected interface by passing provider object to the constructor

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import './App.css';
 import Wallet from '@project-serum/sol-wallet-adapter';
 import { Connection, SystemProgram, clusterApiUrl } from '@solana/web3.js';
+import dotProp from 'dot-prop';
 
 function App() {
   const [logs, setLogs] = useState([]);
@@ -11,11 +12,13 @@ function App() {
 
   const network = clusterApiUrl('devnet');
   const [providerUrl, setProviderUrl] = useState('https://www.sollet.io');
+  const [injectedPath, setInjectedPath] = useState('window.solana');
 
   const connection = useMemo(() => new Connection(network), [network]);
-  const wallet = useMemo(() => new Wallet(providerUrl, network), [
+  const wallet = useMemo(() => new Wallet(providerUrl, network, dotProp.get({window: {solana: window.solana}}, injectedPath)), [
     providerUrl,
     network,
+    injectedPath,
   ]);
   const [, setConnected] = useState(false);
   useEffect(() => {
@@ -66,6 +69,14 @@ function App() {
           type="text"
           value={providerUrl}
           onChange={(e) => setProviderUrl(e.target.value.trim() || window.solana)}
+        />
+      </div>
+      <div>
+        Injected path:{' '}
+        <input
+          type="text"
+          value={injectedPath}
+          onChange={(e) => setInjectedPath(e.target.value.trim())}
         />
       </div>
       {wallet.connected ? (

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -65,7 +65,7 @@ function App() {
         <input
           type="text"
           value={providerUrl}
-          onChange={(e) => setProviderUrl(e.target.value.trim())}
+          onChange={(e) => setProviderUrl(e.target.value.trim() || window.solana)}
         />
       </div>
       {wallet.connected ? (

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "bs58": "^4.0.1",
+    "dot-prop": "^6.0.1",
     "eventemitter3": "^4.0.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,17 +3,16 @@ import { PublicKey } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 export default class Wallet extends EventEmitter {
-  constructor(providerUrl, network) {
+  constructor(providerUrl, network, injectedProvider) {
     super();
-    if (isInjectedProvider(providerUrl)) {
-      this._injectedProvider = providerUrl;
-    } else {
-      this._providerUrl = new URL(providerUrl);
-      this._providerUrl.hash = new URLSearchParams({
-        origin: window.location.origin,
-        network,
-      }).toString();
+    if (injectedProvider && isInjectedProvider(injectedProvider)) {
+      this._injectedProvider = injectedProvider;
     }
+    this._providerUrl = new URL(providerUrl);
+    this._providerUrl.hash = new URLSearchParams({
+      origin: window.location.origin,
+      network,
+    }).toString();
     this._publicKey = null;
     this._autoApprove = false;
     this._popup = null;

--- a/src/index.js
+++ b/src/index.js
@@ -5,18 +5,23 @@ import bs58 from 'bs58';
 export default class Wallet extends EventEmitter {
   constructor(providerUrl, network) {
     super();
-    this._providerUrl = new URL(providerUrl);
-    this._providerUrl.hash = new URLSearchParams({
-      origin: window.location.origin,
-      network,
-    }).toString();
+    try {
+      this._providerUrl = new URL(providerUrl);
+      this._providerUrl.hash = new URLSearchParams({
+        origin: window.location.origin,
+        network,
+      }).toString();
+      this._useInjectedInterface = false;
+    } catch (err) {
+      // invalid URL, use injected interface
+      this._useInjectedInterface = true;
+    }
     this._publicKey = null;
     this._autoApprove = false;
     this._popup = null;
     this._handlerAdded = false;
     this._nextRequestId = 1;
     this._responsePromises = new Map();
-    this._useInjectedInterface = false;
   }
 
   _handleMessage = (e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,13 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
+  dependencies:
+    is-obj "^2.0.0"
+
 dotenv-expand@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"


### PR DESCRIPTION
This minimal change allows sol-wallet-adapter to interact with any browser extension by passing non URL value to the constructor.