### PR TITLE
Fix dangling handlers caused by disconnecting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,11 @@ export default class Wallet extends EventEmitter {
     if (this._popup) {
       this._popup.close();
     }
+    if (this._handlerAdded) {
+      this._handlerAdded = false;
+      window.removeEventListener('message', this._handleMessage);
+      window.removeEventListener('beforeunload', this.disconnect);
+    }
     this._handleDisconnect();
   };
 


### PR DESCRIPTION
Previously, left dangling handlers when disconnecting. This caused a bug when a Dapp supports two different sol-wallet-adapter-based wallets (e.g. sollet.io and the sollet extension) where disconnecting from one and connecting to the other causes incoming messages to still be processed by the disconnected one.