### PR TITLE
Fix CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -P tsconfig.build.json && tsc -P tsconfig.esm.json",
+    "build": "rm -rf dist && tsc -P tsconfig.cjs.json && tsc -P tsconfig.esm.json",
     "start": "tsc --watch",
     "clean": "rm -rf dist",
     "prepare": "run-s clean build",
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "bs58": "^4.0.1",
-    "eventemitter3": "^4.0.7"
+    "eventemitter3": "^4.0.7",
+    "tslib": "^2.3.1"
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/cjs/",
+    "outDir": "dist/cjs/",
+    "target": "ES2015",
+    "module": "CommonJS",
     "noEmit": false,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,14 @@
 {
-  "extends": "./tsconfig.build.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/esm/",
-    "target": "ES6",
-    "module": "ESNext"
-  }
+    "target": "ES2015",
+    "module": "ESNext",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./src",
     "target": "es5",
-    "module": "esnext",
     "moduleResolution": "node",
     "lib": [
       "es2016",
@@ -24,7 +23,8 @@
     ],
     "noEmit": true,
     "allowJs": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "importHelpers": true
   },
   "include": [
     "src/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10954,6 +10954,11 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"


### PR DESCRIPTION
The CommonJS build script was exporting ESM, when it should have been exporting CJS.

I also went ahead and used tslib for awaiting to make the bundle smaller.