### PR TITLE
Fix example to use window.sollet instead of window.solana

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -30,7 +30,7 @@ function App(): React.ReactElement {
   const injectedWallet = useMemo(() => {
     try {
       return new Wallet(
-        (window as unknown as { solana: unknown }).solana,
+        (window as unknown as { sollet: unknown }).sollet,
         network,
       );
     } catch (e) {


### PR DESCRIPTION
As per #26, the wallet is injected into window.sollet and not window.solana.
The example still uses window.solana, so I've fixed it here. 